### PR TITLE
fix: isFirstRun was calling callback method twice.

### DIFF
--- a/ios/RNTreasureData.m
+++ b/ios/RNTreasureData.m
@@ -264,8 +264,6 @@ RCT_EXPORT_METHOD(isFirstRun:
     } else {
         reject(RCTErrorUnspecified, nil, nil);
     }
-
-    resolve([NSNumber numberWithBool:isFirstRun]);
 }
 
 RCT_EXPORT_METHOD(clearFirstRun)


### PR DESCRIPTION
isFirstRun was calling callback method twice.

So, crash and error message was displayed such as:

`only one callback may be registered to a function in a native module`.